### PR TITLE
Fix the unsatisfiable constraints error

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/local/django/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update \
   # Pillow dependencies
   && apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev \
   # CFFI dependencies
-  && apk add libffi-dev openssl-dev py-cffi \
+  && apk add libffi-dev py-cffi \
   # Translations dependencies
   && apk add gettext \
   # https://docs.djangoproject.com/en/dev/ref/django-admin/#dbshell

--- a/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/django/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update \
   # Pillow dependencies
   && apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev \
   # CFFI dependencies
-  && apk add libffi-dev openssl-dev py-cffi
+  && apk add libffi-dev py-cffi
 
 RUN addgroup -S django \
     && adduser -S -G django django


### PR DESCRIPTION
Removed the openssl-dev package from the Django Dockerfiles (local and production) to fix the unsatisfiable constraints error.

The error appears because you can't have openssl and libressl installed at the same time. One of the package used by the template/project installs libressl which create an error when trying to install openssl.